### PR TITLE
Add benchmarks and memory profiling tests for local and NATS transports

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,263 @@
+package zephyr_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	"github.com/RobertWHurst/navaros"
+	"github.com/RobertWHurst/zephyr"
+	"github.com/nats-io/nats.go"
+)
+
+// getNATSURL returns the NATS server URL for testing
+func getNATSURL() string {
+	if url := os.Getenv("NATS_URL"); url != "" {
+		return url
+	}
+	return "nats://localhost:4222"
+}
+
+// setupNATSConnection creates a NATS connection for testing
+func setupNATSConnection(tb testing.TB) *nats.Conn {
+	tb.Helper()
+
+	url := getNATSURL()
+	opts := []nats.Option{
+		nats.Name(fmt.Sprintf("zephyr-test-%s", tb.Name())),
+		nats.MaxReconnects(3),
+		nats.ReconnectWait(time.Second),
+		nats.Timeout(5 * time.Second),
+	}
+
+	nc, err := nats.Connect(url, opts...)
+	if err != nil {
+		tb.Skipf("NATS connection failed (URL: %s): %v", url, err)
+	}
+
+	return nc
+}
+
+// simpleHandler is a basic handler for testing
+var simpleHandler = func(ctx *navaros.Context) {
+	ctx.Status = 200
+	ctx.Body = "OK"
+}
+
+// echoHandler echoes the request body
+var echoHandler = func(ctx *navaros.Context) {
+	body := make([]byte, 0)
+	buf := make([]byte, 1024)
+	for {
+		n, err := ctx.Request().Body.Read(buf)
+		if n > 0 {
+			body = append(body, buf[:n]...)
+		}
+		if err != nil {
+			break
+		}
+	}
+	ctx.Status = 200
+	ctx.Body = body
+}
+
+// setupTestService creates and starts a test service with routes
+func setupTestService(transport zephyr.Transport, name string) *zephyr.Service {
+	router := navaros.NewRouter()
+	router.Get("/test", simpleHandler)
+	router.Post("/test", echoHandler)
+
+	service := zephyr.NewService(name, transport, router)
+	service.RouteDescriptors = []*zephyr.RouteDescriptor{
+		mustRouteDescriptor("GET", "/test"),
+		mustRouteDescriptor("POST", "/test"),
+	}
+
+	if err := service.Start(); err != nil {
+		panic(fmt.Sprintf("Failed to start test service: %v", err))
+	}
+
+	return service
+}
+
+func mustRouteDescriptor(method, pattern string) *zephyr.RouteDescriptor {
+	rd, err := zephyr.NewRouteDescriptor(method, pattern)
+	if err != nil {
+		panic(err)
+	}
+	return rd
+}
+
+// MemoryProfiler wraps heap profiling for tests
+type MemoryProfiler struct {
+	tb          testing.TB
+	profileDir  string
+	profileName string
+	snapshots   []runtime.MemStats
+}
+
+// NewMemoryProfiler creates a new memory profiler
+func NewMemoryProfiler(tb testing.TB, name string) *MemoryProfiler {
+	profileDir := os.Getenv("ZEPHYR_PROFILE_DIR")
+	if profileDir == "" {
+		profileDir = "/tmp/zephyr-profiles"
+	}
+	os.MkdirAll(profileDir, 0755)
+
+	return &MemoryProfiler{
+		tb:          tb,
+		profileDir:  profileDir,
+		profileName: name,
+		snapshots:   make([]runtime.MemStats, 0),
+	}
+}
+
+// Snapshot takes a memory snapshot
+func (mp *MemoryProfiler) Snapshot(label string) {
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	mp.snapshots = append(mp.snapshots, m)
+
+	mp.tb.Logf("[%s] Snapshot %s: HeapAlloc=%d, HeapInuse=%d, NumGC=%d, Goroutines=%d",
+		mp.profileName, label, m.HeapAlloc, m.HeapInuse, m.NumGC, runtime.NumGoroutine())
+}
+
+// WriteHeapProfile writes a heap profile to file
+func (mp *MemoryProfiler) WriteHeapProfile(suffix string) string {
+	filename := filepath.Join(mp.profileDir, mp.profileName+"_"+suffix+".heap")
+	f, err := os.Create(filename)
+	if err != nil {
+		mp.tb.Logf("Failed to create heap profile: %v", err)
+		return ""
+	}
+	defer f.Close()
+
+	runtime.GC()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		mp.tb.Logf("Failed to write heap profile: %v", err)
+		return ""
+	}
+	mp.tb.Logf("Wrote heap profile to %s", filename)
+	return filename
+}
+
+// WriteGoroutineProfile writes a goroutine profile to file
+func (mp *MemoryProfiler) WriteGoroutineProfile(suffix string) string {
+	filename := filepath.Join(mp.profileDir, mp.profileName+"_"+suffix+".goroutine")
+	f, err := os.Create(filename)
+	if err != nil {
+		mp.tb.Logf("Failed to create goroutine profile: %v", err)
+		return ""
+	}
+	defer f.Close()
+
+	if err := pprof.Lookup("goroutine").WriteTo(f, 1); err != nil {
+		mp.tb.Logf("Failed to write goroutine profile: %v", err)
+		return ""
+	}
+	mp.tb.Logf("Wrote goroutine profile to %s", filename)
+	return filename
+}
+
+// AssertNoGrowth verifies memory did not grow significantly between first and last snapshots
+func (mp *MemoryProfiler) AssertNoGrowth(maxGrowthPercent float64) bool {
+	if len(mp.snapshots) < 2 {
+		mp.tb.Log("Not enough snapshots to compare")
+		return true
+	}
+
+	first := mp.snapshots[0]
+	last := mp.snapshots[len(mp.snapshots)-1]
+
+	if first.HeapAlloc == 0 {
+		return true
+	}
+
+	growth := float64(last.HeapAlloc-first.HeapAlloc) / float64(first.HeapAlloc) * 100
+
+	if growth > maxGrowthPercent {
+		mp.tb.Errorf("Memory grew by %.2f%% (HeapAlloc: %d -> %d), max allowed: %.2f%%",
+			growth, first.HeapAlloc, last.HeapAlloc, maxGrowthPercent)
+		mp.WriteHeapProfile("leak_detected")
+		return false
+	}
+	return true
+}
+
+// CheckGoroutineLeak verifies no goroutine leak occurred
+func (mp *MemoryProfiler) CheckGoroutineLeak(initialCount int, maxGrowth int) bool {
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC()
+
+	finalCount := runtime.NumGoroutine()
+
+	if finalCount-initialCount > maxGrowth {
+		mp.tb.Errorf("Goroutine leak detected: started with %d, ended with %d (leaked %d)",
+			initialCount, finalCount, finalCount-initialCount)
+		mp.WriteGoroutineProfile("goroutine_leak")
+		return false
+	}
+	return true
+}
+
+// GetMemoryGrowthSlope calculates the memory growth trend from snapshots
+func (mp *MemoryProfiler) GetMemoryGrowthSlope() float64 {
+	if len(mp.snapshots) < 3 {
+		return 0
+	}
+
+	samples := make([]uint64, len(mp.snapshots))
+	for i, s := range mp.snapshots {
+		samples[i] = s.HeapAlloc
+	}
+
+	return calculateMemorySlope(samples)
+}
+
+// calculateMemorySlope calculates linear regression slope for memory samples
+func calculateMemorySlope(samples []uint64) float64 {
+	n := float64(len(samples))
+	var sumX, sumY, sumXY, sumX2 float64
+
+	for i, y := range samples {
+		x := float64(i)
+		sumX += x
+		sumY += float64(y)
+		sumXY += x * float64(y)
+		sumX2 += x * x
+	}
+
+	denominator := n*sumX2 - sumX*sumX
+	if denominator == 0 {
+		return 0
+	}
+
+	return (n*sumXY - sumX*sumY) / denominator
+}
+
+// assertMemoryStable verifies memory samples do not show consistent growth
+func assertMemoryStable(tb testing.TB, samples []uint64) {
+	tb.Helper()
+
+	if len(samples) < 3 {
+		return
+	}
+
+	growthCount := 0
+	for i := 1; i < len(samples); i++ {
+		if samples[i] > samples[i-1] {
+			growthCount++
+		}
+	}
+
+	growthRatio := float64(growthCount) / float64(len(samples)-1)
+	if growthRatio > 0.7 {
+		tb.Errorf("Memory appears to be growing consistently (%.0f%% of samples show increase)",
+			growthRatio*100)
+	}
+}

--- a/local-transport/dispatch_bench_test.go
+++ b/local-transport/dispatch_bench_test.go
@@ -1,0 +1,293 @@
+package localtransport_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/RobertWHurst/navaros"
+	"github.com/RobertWHurst/zephyr"
+	localtransport "github.com/RobertWHurst/zephyr/local-transport"
+)
+
+// simpleHandler is a basic handler for benchmarking
+var simpleHandler = func(ctx *navaros.Context) {
+	ctx.Status = 200
+	ctx.Body = "OK"
+}
+
+// echoHandler echoes the request body
+var echoHandler = func(ctx *navaros.Context) {
+	body := make([]byte, 0)
+	buf := make([]byte, 1024)
+	for {
+		n, err := ctx.Request().Body.Read(buf)
+		if n > 0 {
+			body = append(body, buf[:n]...)
+		}
+		if err != nil {
+			break
+		}
+	}
+	ctx.Status = 200
+	ctx.Body = body
+}
+
+func mustRouteDescriptor(method, pattern string) *zephyr.RouteDescriptor {
+	rd, err := zephyr.NewRouteDescriptor(method, pattern)
+	if err != nil {
+		panic(err)
+	}
+	return rd
+}
+
+// setupBenchService creates and starts a test service
+func setupBenchService(transport *localtransport.LocalTransport, name string) *zephyr.Service {
+	router := navaros.NewRouter()
+	router.Get("/test", simpleHandler)
+	router.Post("/test", echoHandler)
+
+	service := zephyr.NewService(name, transport, router)
+	service.RouteDescriptors = []*zephyr.RouteDescriptor{
+		mustRouteDescriptor("GET", "/test"),
+		mustRouteDescriptor("POST", "/test"),
+	}
+
+	if err := service.Start(); err != nil {
+		panic(fmt.Sprintf("Failed to start test service: %v", err))
+	}
+
+	return service
+}
+
+// BenchmarkLocalDispatch_HighVolume tests memory stability under high request volume
+func BenchmarkLocalDispatch_HighVolume(b *testing.B) {
+	transport := localtransport.New()
+
+	gateway := zephyr.NewGateway("bench-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	service := setupBenchService(transport, "high-volume-service")
+	defer service.Stop()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		rec := httptest.NewRecorder()
+		transport.Dispatch("high-volume-service", rec, req)
+	}
+}
+
+// BenchmarkLocalDispatch_Concurrent tests concurrent request handling
+func BenchmarkLocalDispatch_Concurrent(b *testing.B) {
+	transport := localtransport.New()
+
+	gateway := zephyr.NewGateway("bench-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	service := setupBenchService(transport, "concurrent-service")
+	defer service.Stop()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.SetParallelism(100)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req := httptest.NewRequest("GET", "/test", nil)
+			rec := httptest.NewRecorder()
+			transport.Dispatch("concurrent-service", rec, req)
+		}
+	})
+}
+
+// BenchmarkLocalDispatch_LargePayload tests memory handling with large payloads
+func BenchmarkLocalDispatch_LargePayload(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1KB", 1024},
+		{"10KB", 10 * 1024},
+		{"100KB", 100 * 1024},
+		{"1MB", 1024 * 1024},
+	}
+
+	for _, size := range sizes {
+		b.Run(size.name, func(b *testing.B) {
+			transport := localtransport.New()
+
+			gateway := zephyr.NewGateway("bench-gateway", transport)
+			gateway.Start()
+			defer gateway.Stop()
+
+			service := setupBenchService(transport, fmt.Sprintf("payload-service-%s", size.name))
+			defer service.Stop()
+
+			payload := bytes.Repeat([]byte("x"), size.size)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			b.SetBytes(int64(size.size * 2)) // Request + Response
+
+			for i := 0; i < b.N; i++ {
+				req := httptest.NewRequest("POST", "/test", bytes.NewReader(payload))
+				rec := httptest.NewRecorder()
+				transport.Dispatch(fmt.Sprintf("payload-service-%s", size.name), rec, req)
+			}
+		})
+	}
+}
+
+// BenchmarkLocalDispatch_ServiceStartStop benchmarks service lifecycle
+func BenchmarkLocalDispatch_ServiceStartStop(b *testing.B) {
+	transport := localtransport.New()
+
+	gateway := zephyr.NewGateway("bench-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		service := zephyr.NewService(
+			fmt.Sprintf("lifecycle-service-%d", i%100),
+			transport,
+			simpleHandler,
+		)
+		service.Start()
+		service.Stop()
+	}
+}
+
+// TestLocalDispatchMemoryProfile runs dispatch with detailed memory profiling
+func TestLocalDispatchMemoryProfile(t *testing.T) {
+	if os.Getenv("ZEPHYR_PROFILE") != "1" {
+		t.Skip("Profiling disabled. Set ZEPHYR_PROFILE=1 to enable")
+	}
+
+	transport := localtransport.New()
+
+	gateway := zephyr.NewGateway("profile-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	service := setupBenchService(transport, "profile-service")
+	defer service.Stop()
+
+	const iterations = 5000
+	const sampleInterval = 500
+
+	var memSamples []uint64
+
+	// Warmup
+	for i := 0; i < 500; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		rec := httptest.NewRecorder()
+		transport.Dispatch("profile-service", rec, req)
+	}
+
+	runtime.GC()
+
+	for i := 0; i < iterations; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		rec := httptest.NewRecorder()
+		transport.Dispatch("profile-service", rec, req)
+
+		if i > 0 && i%sampleInterval == 0 {
+			runtime.GC()
+			var m runtime.MemStats
+			runtime.ReadMemStats(&m)
+			memSamples = append(memSamples, m.HeapAlloc)
+			t.Logf("Iteration %d: HeapAlloc=%d, NumGC=%d", i, m.HeapAlloc, m.NumGC)
+		}
+	}
+
+	// Check for consistent growth
+	if len(memSamples) >= 3 {
+		growthCount := 0
+		for i := 1; i < len(memSamples); i++ {
+			if memSamples[i] > memSamples[i-1] {
+				growthCount++
+			}
+		}
+		growthRatio := float64(growthCount) / float64(len(memSamples)-1)
+		t.Logf("Growth ratio: %.2f%% of samples showed increase", growthRatio*100)
+
+		if growthRatio > 0.8 {
+			t.Errorf("Memory appears to be consistently growing")
+		}
+	}
+}
+
+// TestLocalServiceRegistrationMemory tests service registration/deregistration memory
+func TestLocalServiceRegistrationMemory(t *testing.T) {
+	transport := localtransport.New()
+
+	gateway := zephyr.NewGateway("test-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	initialGoroutines := runtime.NumGoroutine()
+	t.Logf("Initial goroutines: %d", initialGoroutines)
+
+	const cycles = 100
+
+	// Warmup
+	for i := 0; i < 10; i++ {
+		service := zephyr.NewService(fmt.Sprintf("warmup-%d", i), transport, simpleHandler)
+		service.Start()
+		service.Stop()
+	}
+
+	runtime.GC()
+	var baselineMem runtime.MemStats
+	runtime.ReadMemStats(&baselineMem)
+
+	for i := 0; i < cycles; i++ {
+		service := zephyr.NewService(fmt.Sprintf("cycle-service-%d", i), transport, simpleHandler)
+		service.Start()
+
+		// Do some work
+		for j := 0; j < 50; j++ {
+			req := httptest.NewRequest("GET", "/test", nil)
+			rec := httptest.NewRecorder()
+			transport.Dispatch(fmt.Sprintf("cycle-service-%d", i), rec, req)
+		}
+
+		service.Stop()
+	}
+
+	runtime.GC()
+	runtime.GC()
+
+	var finalMem runtime.MemStats
+	runtime.ReadMemStats(&finalMem)
+
+	finalGoroutines := runtime.NumGoroutine()
+
+	t.Logf("Memory: baseline=%d, final=%d, diff=%d",
+		baselineMem.HeapAlloc, finalMem.HeapAlloc, finalMem.HeapAlloc-baselineMem.HeapAlloc)
+	t.Logf("Goroutines: initial=%d, final=%d", initialGoroutines, finalGoroutines)
+
+	// Check for significant memory growth
+	memGrowth := finalMem.HeapAlloc - baselineMem.HeapAlloc
+	maxGrowthBytes := uint64(5 * 1024 * 1024) // 5MB max growth
+	if memGrowth > maxGrowthBytes {
+		t.Errorf("Significant memory growth detected: %d bytes (max: %d)", memGrowth, maxGrowthBytes)
+	}
+
+	// Check for goroutine leaks
+	goroutineLeak := finalGoroutines - initialGoroutines
+	if goroutineLeak > 5 {
+		t.Errorf("Goroutine leak detected: %d goroutines leaked", goroutineLeak)
+	}
+}

--- a/memory_test.go
+++ b/memory_test.go
@@ -1,0 +1,445 @@
+package zephyr_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/RobertWHurst/zephyr"
+	localtransport "github.com/RobertWHurst/zephyr/local-transport"
+	natstransport "github.com/RobertWHurst/zephyr/nats-transport"
+)
+
+// TestIterativeMemoryGrowth_Local runs multiple iterations and checks for memory growth using local transport
+func TestIterativeMemoryGrowth_Local(t *testing.T) {
+	transport := localtransport.New()
+
+	gateway := zephyr.NewGateway("test-gateway", transport)
+	if err := gateway.Start(); err != nil {
+		t.Fatalf("Failed to start gateway: %v", err)
+	}
+	defer gateway.Stop()
+
+	service := setupTestService(transport, "growth-test-service")
+	defer service.Stop()
+
+	const (
+		warmupIterations = 500
+		testIterations   = 3000
+		sampleInterval   = 500
+	)
+
+	// Warmup phase
+	for i := 0; i < warmupIterations; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		rec := httptest.NewRecorder()
+		transport.Dispatch("growth-test-service", rec, req)
+	}
+
+	// Force GC after warmup
+	runtime.GC()
+	runtime.GC()
+
+	profiler := NewMemoryProfiler(t, "iterative_growth_local")
+	profiler.Snapshot("baseline")
+
+	// Test phase
+	for i := 0; i < testIterations; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		rec := httptest.NewRecorder()
+		transport.Dispatch("growth-test-service", rec, req)
+
+		if i > 0 && i%sampleInterval == 0 {
+			profiler.Snapshot(fmt.Sprintf("iteration_%d", i))
+		}
+	}
+
+	profiler.Snapshot("final")
+
+	// Analyze growth trend
+	slope := profiler.GetMemoryGrowthSlope()
+	bytesPerIteration := slope / float64(sampleInterval)
+
+	t.Logf("Memory trend: %.2f bytes per iteration", bytesPerIteration)
+
+	// Flag if growing more than 100 bytes per request (allowing some tolerance)
+	if bytesPerIteration > 100 {
+		t.Errorf("Memory growing at %.2f bytes per iteration (threshold: 100)", bytesPerIteration)
+		profiler.WriteHeapProfile("growth_detected")
+	}
+
+	profiler.AssertNoGrowth(50.0) // Max 50% growth allowed
+}
+
+// TestIterativeMemoryGrowth_NATS runs multiple iterations and checks for memory growth using NATS transport
+func TestIterativeMemoryGrowth_NATS(t *testing.T) {
+	nc := setupNATSConnection(t)
+	defer nc.Close()
+
+	transport := natstransport.New(nc)
+
+	gateway := zephyr.NewGateway("test-gateway", transport)
+	if err := gateway.Start(); err != nil {
+		t.Fatalf("Failed to start gateway: %v", err)
+	}
+	defer gateway.Stop()
+
+	service := setupTestService(transport, "growth-test-service-nats")
+	defer service.Stop()
+
+	// Allow service discovery
+	time.Sleep(100 * time.Millisecond)
+
+	const (
+		warmupIterations = 200
+		testIterations   = 1000
+		sampleInterval   = 200
+	)
+
+	// Warmup phase
+	for i := 0; i < warmupIterations; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		rec := httptest.NewRecorder()
+		transport.Dispatch("growth-test-service-nats", rec, req)
+	}
+
+	// Force GC after warmup
+	runtime.GC()
+	runtime.GC()
+
+	profiler := NewMemoryProfiler(t, "iterative_growth_nats")
+	profiler.Snapshot("baseline")
+
+	// Test phase
+	for i := 0; i < testIterations; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		rec := httptest.NewRecorder()
+		transport.Dispatch("growth-test-service-nats", rec, req)
+
+		if i > 0 && i%sampleInterval == 0 {
+			profiler.Snapshot(fmt.Sprintf("iteration_%d", i))
+		}
+	}
+
+	profiler.Snapshot("final")
+
+	slope := profiler.GetMemoryGrowthSlope()
+	bytesPerIteration := slope / float64(sampleInterval)
+
+	t.Logf("Memory trend: %.2f bytes per iteration", bytesPerIteration)
+
+	if bytesPerIteration > 200 {
+		t.Errorf("Memory growing at %.2f bytes per iteration (threshold: 200)", bytesPerIteration)
+		profiler.WriteHeapProfile("growth_detected")
+	}
+
+	profiler.AssertNoGrowth(50.0)
+}
+
+// TestGoroutineLeak_Local tests for goroutine leaks with local transport
+func TestGoroutineLeak_Local(t *testing.T) {
+	transport := localtransport.New()
+
+	initialGoroutines := runtime.NumGoroutine()
+	t.Logf("Initial goroutines: %d", initialGoroutines)
+
+	const cycles = 30
+
+	for cycle := 0; cycle < cycles; cycle++ {
+		service := zephyr.NewService(
+			fmt.Sprintf("goroutine-test-local-%d", cycle),
+			transport,
+			simpleHandler,
+		)
+		service.Start()
+
+		// Execute requests
+		for i := 0; i < 50; i++ {
+			req := httptest.NewRequest("GET", "/test", nil)
+			rec := httptest.NewRecorder()
+			transport.Dispatch(fmt.Sprintf("goroutine-test-local-%d", cycle), rec, req)
+		}
+
+		service.Stop()
+	}
+
+	// Allow time for goroutines to exit
+	time.Sleep(200 * time.Millisecond)
+	runtime.GC()
+
+	finalGoroutines := runtime.NumGoroutine()
+	t.Logf("Final goroutines: %d", finalGoroutines)
+
+	maxGrowth := 10
+	if finalGoroutines-initialGoroutines > maxGrowth {
+		t.Errorf("Goroutine leak: started with %d, ended with %d (leaked %d)",
+			initialGoroutines, finalGoroutines, finalGoroutines-initialGoroutines)
+
+		// Dump goroutine stacks for debugging
+		buf := make([]byte, 64*1024)
+		n := runtime.Stack(buf, true)
+		t.Logf("Goroutine dump:\n%s", buf[:n])
+	}
+}
+
+// TestGoroutineLeak_NATS tests for goroutine leaks with NATS transport
+func TestGoroutineLeak_NATS(t *testing.T) {
+	nc := setupNATSConnection(t)
+	defer nc.Close()
+
+	transport := natstransport.New(nc)
+
+	initialGoroutines := runtime.NumGoroutine()
+	t.Logf("Initial goroutines: %d", initialGoroutines)
+
+	const cycles = 20
+
+	for cycle := 0; cycle < cycles; cycle++ {
+		service := zephyr.NewService(
+			fmt.Sprintf("goroutine-test-nats-%d", cycle),
+			transport,
+			simpleHandler,
+		)
+		service.Start()
+
+		// Execute requests
+		for i := 0; i < 30; i++ {
+			req := httptest.NewRequest("GET", "/test", nil)
+			rec := httptest.NewRecorder()
+			transport.Dispatch(fmt.Sprintf("goroutine-test-nats-%d", cycle), rec, req)
+		}
+
+		service.Stop()
+	}
+
+	// Allow time for goroutines to exit
+	time.Sleep(300 * time.Millisecond)
+	runtime.GC()
+
+	finalGoroutines := runtime.NumGoroutine()
+	t.Logf("Final goroutines: %d", finalGoroutines)
+
+	maxGrowth := 10
+	if finalGoroutines-initialGoroutines > maxGrowth {
+		t.Errorf("Goroutine leak: started with %d, ended with %d (leaked %d)",
+			initialGoroutines, finalGoroutines, finalGoroutines-initialGoroutines)
+
+		buf := make([]byte, 64*1024)
+		n := runtime.Stack(buf, true)
+		t.Logf("Goroutine dump:\n%s", buf[:n])
+	}
+}
+
+// TestServiceRegistrationCycle_Local tests service start/stop cycles for memory leaks
+func TestServiceRegistrationCycle_Local(t *testing.T) {
+	transport := localtransport.New()
+
+	gateway := zephyr.NewGateway("test-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	profiler := NewMemoryProfiler(t, "service_registration_local")
+
+	const cycles = 50
+
+	// Warmup
+	for i := 0; i < 10; i++ {
+		service := zephyr.NewService(fmt.Sprintf("warmup-service-%d", i), transport, simpleHandler)
+		service.Start()
+		service.Stop()
+	}
+
+	runtime.GC()
+	profiler.Snapshot("baseline")
+
+	for i := 0; i < cycles; i++ {
+		service := zephyr.NewService(fmt.Sprintf("cycle-service-%d", i), transport, simpleHandler)
+		service.Start()
+
+		// Do some work
+		for j := 0; j < 20; j++ {
+			req := httptest.NewRequest("GET", "/test", nil)
+			rec := httptest.NewRecorder()
+			transport.Dispatch(fmt.Sprintf("cycle-service-%d", i), rec, req)
+		}
+
+		service.Stop()
+
+		if i > 0 && i%10 == 0 {
+			runtime.GC()
+			profiler.Snapshot(fmt.Sprintf("cycle_%d", i))
+		}
+	}
+
+	runtime.GC()
+	profiler.Snapshot("final")
+
+	profiler.AssertNoGrowth(30.0) // Max 30% growth
+}
+
+// TestServiceRegistrationCycle_NATS tests service start/stop cycles with NATS
+func TestServiceRegistrationCycle_NATS(t *testing.T) {
+	nc := setupNATSConnection(t)
+	defer nc.Close()
+
+	transport := natstransport.New(nc)
+
+	gateway := zephyr.NewGateway("test-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	profiler := NewMemoryProfiler(t, "service_registration_nats")
+
+	const cycles = 30
+
+	// Warmup
+	for i := 0; i < 5; i++ {
+		service := zephyr.NewService(fmt.Sprintf("warmup-service-nats-%d", i), transport, simpleHandler)
+		service.Start()
+		time.Sleep(50 * time.Millisecond)
+		service.Stop()
+	}
+
+	runtime.GC()
+	profiler.Snapshot("baseline")
+
+	for i := 0; i < cycles; i++ {
+		service := zephyr.NewService(fmt.Sprintf("cycle-service-nats-%d", i), transport, simpleHandler)
+		service.Start()
+		time.Sleep(20 * time.Millisecond)
+
+		// Do some work
+		for j := 0; j < 10; j++ {
+			req := httptest.NewRequest("GET", "/test", nil)
+			rec := httptest.NewRecorder()
+			transport.Dispatch(fmt.Sprintf("cycle-service-nats-%d", i), rec, req)
+		}
+
+		service.Stop()
+
+		if i > 0 && i%10 == 0 {
+			runtime.GC()
+			profiler.Snapshot(fmt.Sprintf("cycle_%d", i))
+		}
+	}
+
+	runtime.GC()
+	profiler.Snapshot("final")
+
+	profiler.AssertNoGrowth(30.0)
+}
+
+// TestMemoryRelease_LargePayload_Local verifies buffers are released after large requests
+func TestMemoryRelease_LargePayload_Local(t *testing.T) {
+	transport := localtransport.New()
+
+	gateway := zephyr.NewGateway("test-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	service := setupTestService(transport, "large-payload-service")
+	defer service.Stop()
+
+	profiler := NewMemoryProfiler(t, "large_payload_local")
+
+	// Generate 1MB payload
+	payloadSize := 1024 * 1024
+	payload := bytes.Repeat([]byte("x"), payloadSize)
+
+	// Warmup
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("POST", "/test", bytes.NewReader(payload))
+		rec := httptest.NewRecorder()
+		transport.Dispatch("large-payload-service", rec, req)
+	}
+
+	runtime.GC()
+	runtime.GC()
+	profiler.Snapshot("after_warmup")
+
+	// Execute requests with large payloads
+	numRequests := 20
+	for i := 0; i < numRequests; i++ {
+		req := httptest.NewRequest("POST", "/test", bytes.NewReader(payload))
+		rec := httptest.NewRecorder()
+		transport.Dispatch("large-payload-service", rec, req)
+	}
+
+	// Force GC
+	runtime.GC()
+	runtime.GC()
+	profiler.Snapshot("after_requests")
+
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	// Heap should not retain all the payload data
+	// Allow for ~5MB overhead after 20x1MB requests
+	maxExpectedHeap := uint64(20 * 1024 * 1024)
+	if m.HeapAlloc > maxExpectedHeap {
+		t.Errorf("Heap allocation too high after large payloads: %d bytes (expected < %d)",
+			m.HeapAlloc, maxExpectedHeap)
+		profiler.WriteHeapProfile("large_payload_retained")
+	}
+}
+
+// TestMemoryRelease_LargePayload_NATS verifies buffers are released with NATS transport
+func TestMemoryRelease_LargePayload_NATS(t *testing.T) {
+	nc := setupNATSConnection(t)
+	defer nc.Close()
+
+	transport := natstransport.New(nc)
+
+	gateway := zephyr.NewGateway("test-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	service := setupTestService(transport, "large-payload-service-nats")
+	defer service.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+
+	profiler := NewMemoryProfiler(t, "large_payload_nats")
+
+	// Generate 100KB payload (smaller for NATS to avoid message size limits)
+	payloadSize := 100 * 1024
+	payload := bytes.Repeat([]byte("x"), payloadSize)
+
+	// Warmup
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("POST", "/test", bytes.NewReader(payload))
+		rec := httptest.NewRecorder()
+		transport.Dispatch("large-payload-service-nats", rec, req)
+	}
+
+	runtime.GC()
+	runtime.GC()
+	profiler.Snapshot("after_warmup")
+
+	// Execute requests with large payloads
+	numRequests := 20
+	for i := 0; i < numRequests; i++ {
+		req := httptest.NewRequest("POST", "/test", bytes.NewReader(payload))
+		rec := httptest.NewRecorder()
+		transport.Dispatch("large-payload-service-nats", rec, req)
+	}
+
+	// Force GC
+	runtime.GC()
+	runtime.GC()
+	profiler.Snapshot("after_requests")
+
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	// Allow for ~10MB overhead after 20x100KB requests
+	maxExpectedHeap := uint64(15 * 1024 * 1024)
+	if m.HeapAlloc > maxExpectedHeap {
+		t.Errorf("Heap allocation too high after large payloads: %d bytes (expected < %d)",
+			m.HeapAlloc, maxExpectedHeap)
+		profiler.WriteHeapProfile("large_payload_retained")
+	}
+}

--- a/nats-transport/dispatch.go
+++ b/nats-transport/dispatch.go
@@ -135,13 +135,25 @@ func (c *NatsTransport) Dispatch(serviceName string, res http.ResponseWriter, re
 		transportNatsDispatchDebug.Tracef("Failed to subscribe to response subject %s: %v", responseSubject, err)
 		return err
 	}
-	
+	defer func() {
+		transportNatsDispatchDebug.Trace("Unsubscribing from response subject")
+		if err := responseSub.Unsubscribe(); err != nil {
+			transportNatsDispatchDebug.Tracef("Failed to unsubscribe from response subject: %v", err)
+		}
+	}()
+
 	transportNatsDispatchDebug.Tracef("Setting up response body subscription to %s", responseBodySubject)
 	responseBodySub, err := c.NatsConnection.SubscribeSync(responseBodySubject)
 	if err != nil {
 		transportNatsDispatchDebug.Tracef("Failed to subscribe to response body subject %s: %v", responseBodySubject, err)
 		return err
 	}
+	defer func() {
+		transportNatsDispatchDebug.Trace("Unsubscribing from response body subject")
+		if err := responseBodySub.Unsubscribe(); err != nil {
+			transportNatsDispatchDebug.Tracef("Failed to unsubscribe from response body subject: %v", err)
+		}
+	}()
 
 	transportNatsDispatchDebug.Tracef("Sending request to %s", requestSubject)
 	requestAckMsg, err := c.NatsConnection.Request(requestSubject, requestBytes, DispatchTimeout)
@@ -228,12 +240,6 @@ func (c *NatsTransport) Dispatch(serviceName string, res http.ResponseWriter, re
 		return err
 	}
 	
-	transportNatsDispatchDebug.Trace("Unsubscribing from response subject")
-	if err := responseSub.Unsubscribe(); err != nil {
-		transportNatsDispatchDebug.Tracef("Failed to unsubscribe from response subject: %v", err)
-		return err
-	}
-
 	transportNatsDispatchDebug.Trace("Unmarshaling response headers")
 	response := &Response{}
 	if err := msgpack.Unmarshal(responseMsg.Data, response); err != nil {
@@ -273,12 +279,6 @@ func (c *NatsTransport) Dispatch(serviceName string, res http.ResponseWriter, re
 			transportNatsDispatchDebug.Trace("Received final body chunk (EOF)")
 			break
 		}
-	}
-
-	transportNatsDispatchDebug.Trace("Unsubscribing from response body subject")
-	if err := responseBodySub.Unsubscribe(); err != nil {
-		transportNatsDispatchDebug.Tracef("Failed to unsubscribe from response body subject: %v", err)
-		return err
 	}
 
 	transportNatsDispatchDebug.Trace("Dispatch completed successfully")
@@ -478,6 +478,12 @@ func (c *NatsTransport) handleDispatch(msg *nats.Msg, handler func(res http.Resp
 		transportNatsDispatchDebug.Tracef("Failed to subscribe to request body subject: %v", err)
 		return err
 	}
+	defer func() {
+		transportNatsDispatchDebug.Trace("Unsubscribing from request body subject")
+		if err := reqBodySubscription.Unsubscribe(); err != nil {
+			transportNatsDispatchDebug.Tracef("Failed to unsubscribe from request body subject: %v", err)
+		}
+	}()
 
 	reqReader := &requestReader{
 		natsSubscription: reqBodySubscription,
@@ -565,6 +571,7 @@ func (c *NatsTransport) UnbindDispatch(serviceName string) error {
 				return err
 			}
 		}
+		delete(c.unbindDispatch, serviceName)
 	}
 	return nil
 }

--- a/nats-transport/dispatch_bench_test.go
+++ b/nats-transport/dispatch_bench_test.go
@@ -1,0 +1,331 @@
+package natstransport_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/RobertWHurst/navaros"
+	"github.com/RobertWHurst/zephyr"
+	natstransport "github.com/RobertWHurst/zephyr/nats-transport"
+	"github.com/nats-io/nats.go"
+)
+
+// getNATSURL returns the NATS server URL for testing
+func getNATSURL() string {
+	if url := os.Getenv("NATS_URL"); url != "" {
+		return url
+	}
+	return "nats://localhost:4222"
+}
+
+// setupNATSConnection creates a NATS connection for testing
+func setupNATSConnection(tb testing.TB) *nats.Conn {
+	tb.Helper()
+
+	url := getNATSURL()
+	opts := []nats.Option{
+		nats.Name(fmt.Sprintf("zephyr-bench-%s", tb.Name())),
+		nats.MaxReconnects(3),
+		nats.ReconnectWait(time.Second),
+		nats.Timeout(5 * time.Second),
+	}
+
+	nc, err := nats.Connect(url, opts...)
+	if err != nil {
+		tb.Skipf("NATS connection failed (URL: %s): %v", url, err)
+	}
+
+	return nc
+}
+
+// simpleHandler is a basic handler for benchmarking
+var simpleHandler = func(ctx *navaros.Context) {
+	ctx.Status = 200
+	ctx.Body = "OK"
+}
+
+// echoHandler echoes the request body
+var echoHandler = func(ctx *navaros.Context) {
+	body := make([]byte, 0)
+	buf := make([]byte, 1024)
+	for {
+		n, err := ctx.Request().Body.Read(buf)
+		if n > 0 {
+			body = append(body, buf[:n]...)
+		}
+		if err != nil {
+			break
+		}
+	}
+	ctx.Status = 200
+	ctx.Body = body
+}
+
+func mustRouteDescriptor(method, pattern string) *zephyr.RouteDescriptor {
+	rd, err := zephyr.NewRouteDescriptor(method, pattern)
+	if err != nil {
+		panic(err)
+	}
+	return rd
+}
+
+// setupBenchService creates and starts a test service
+func setupBenchService(transport *natstransport.NatsTransport, name string) *zephyr.Service {
+	router := navaros.NewRouter()
+	router.Get("/test", simpleHandler)
+	router.Post("/test", echoHandler)
+
+	service := zephyr.NewService(name, transport, router)
+	service.RouteDescriptors = []*zephyr.RouteDescriptor{
+		mustRouteDescriptor("GET", "/test"),
+		mustRouteDescriptor("POST", "/test"),
+	}
+
+	if err := service.Start(); err != nil {
+		panic(fmt.Sprintf("Failed to start test service: %v", err))
+	}
+
+	return service
+}
+
+// BenchmarkNatsDispatch_HighVolume tests memory stability under high request volume
+func BenchmarkNatsDispatch_HighVolume(b *testing.B) {
+	nc := setupNATSConnection(b)
+	defer nc.Close()
+
+	transport := natstransport.New(nc)
+
+	gateway := zephyr.NewGateway("bench-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	service := setupBenchService(transport, "high-volume-service")
+	defer service.Stop()
+
+	// Allow service discovery
+	time.Sleep(100 * time.Millisecond)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		rec := httptest.NewRecorder()
+		transport.Dispatch("high-volume-service", rec, req)
+	}
+}
+
+// BenchmarkNatsDispatch_Concurrent tests concurrent request handling
+func BenchmarkNatsDispatch_Concurrent(b *testing.B) {
+	nc := setupNATSConnection(b)
+	defer nc.Close()
+
+	transport := natstransport.New(nc)
+
+	gateway := zephyr.NewGateway("bench-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	service := setupBenchService(transport, "concurrent-service")
+	defer service.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.SetParallelism(50)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req := httptest.NewRequest("GET", "/test", nil)
+			rec := httptest.NewRecorder()
+			transport.Dispatch("concurrent-service", rec, req)
+		}
+	})
+}
+
+// BenchmarkNatsDispatch_LargePayload tests memory handling with large payloads
+func BenchmarkNatsDispatch_LargePayload(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1KB", 1024},
+		{"10KB", 10 * 1024},
+		{"100KB", 100 * 1024},
+	}
+
+	nc := setupNATSConnection(b)
+	defer nc.Close()
+
+	for _, size := range sizes {
+		b.Run(size.name, func(b *testing.B) {
+			transport := natstransport.New(nc)
+
+			gateway := zephyr.NewGateway("bench-gateway", transport)
+			gateway.Start()
+			defer gateway.Stop()
+
+			service := setupBenchService(transport, fmt.Sprintf("payload-service-%s", size.name))
+			defer service.Stop()
+
+			time.Sleep(100 * time.Millisecond)
+
+			payload := bytes.Repeat([]byte("x"), size.size)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			b.SetBytes(int64(size.size * 2)) // Request + Response
+
+			for i := 0; i < b.N; i++ {
+				req := httptest.NewRequest("POST", "/test", bytes.NewReader(payload))
+				rec := httptest.NewRecorder()
+				transport.Dispatch(fmt.Sprintf("payload-service-%s", size.name), rec, req)
+			}
+		})
+	}
+}
+
+// TestNatsSubscriptionLeak verifies subscriptions are properly cleaned up
+func TestNatsSubscriptionLeak(t *testing.T) {
+	nc := setupNATSConnection(t)
+	defer nc.Close()
+
+	transport := natstransport.New(nc)
+
+	gateway := zephyr.NewGateway("sub-leak-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	// Record initial subscription count
+	initialSubs := nc.NumSubscriptions()
+	t.Logf("Initial subscriptions: %d", initialSubs)
+
+	const numIterations = 100
+
+	for i := 0; i < numIterations; i++ {
+		serviceName := fmt.Sprintf("sub-test-service-%d", i)
+
+		service := zephyr.NewService(serviceName, transport, simpleHandler)
+		service.Start()
+
+		time.Sleep(20 * time.Millisecond)
+
+		// Execute some requests
+		for j := 0; j < 5; j++ {
+			req := httptest.NewRequest("GET", "/test", nil)
+			rec := httptest.NewRecorder()
+			transport.Dispatch(serviceName, rec, req)
+		}
+
+		service.Stop()
+	}
+
+	// Give time for cleanup
+	time.Sleep(200 * time.Millisecond)
+
+	finalSubs := nc.NumSubscriptions()
+	t.Logf("Final subscriptions: %d", finalSubs)
+
+	// Subscriptions should return close to initial count
+	maxAllowedGrowth := 20 // Allow margin for internal NATS subscriptions
+	if finalSubs-initialSubs > maxAllowedGrowth {
+		t.Errorf("Subscription leak detected: started with %d, ended with %d (growth: %d)",
+			initialSubs, finalSubs, finalSubs-initialSubs)
+	}
+}
+
+// TestNatsDispatchMemoryProfile runs dispatch with detailed memory profiling
+func TestNatsDispatchMemoryProfile(t *testing.T) {
+	if os.Getenv("ZEPHYR_PROFILE") != "1" {
+		t.Skip("Profiling disabled. Set ZEPHYR_PROFILE=1 to enable")
+	}
+
+	nc := setupNATSConnection(t)
+	defer nc.Close()
+
+	transport := natstransport.New(nc)
+
+	gateway := zephyr.NewGateway("profile-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	service := setupBenchService(transport, "profile-service")
+	defer service.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+
+	const iterations = 1000
+	const sampleInterval = 100
+
+	var memSamples []uint64
+
+	// Warmup
+	for i := 0; i < 100; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		rec := httptest.NewRecorder()
+		transport.Dispatch("profile-service", rec, req)
+	}
+
+	runtime.GC()
+
+	for i := 0; i < iterations; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		rec := httptest.NewRecorder()
+		transport.Dispatch("profile-service", rec, req)
+
+		if i > 0 && i%sampleInterval == 0 {
+			runtime.GC()
+			var m runtime.MemStats
+			runtime.ReadMemStats(&m)
+			memSamples = append(memSamples, m.HeapAlloc)
+			t.Logf("Iteration %d: HeapAlloc=%d, NumGC=%d", i, m.HeapAlloc, m.NumGC)
+		}
+	}
+
+	// Check for consistent growth
+	if len(memSamples) >= 3 {
+		growthCount := 0
+		for i := 1; i < len(memSamples); i++ {
+			if memSamples[i] > memSamples[i-1] {
+				growthCount++
+			}
+		}
+		growthRatio := float64(growthCount) / float64(len(memSamples)-1)
+		t.Logf("Growth ratio: %.2f%% of samples showed increase", growthRatio*100)
+
+		if growthRatio > 0.8 {
+			t.Errorf("Memory appears to be consistently growing")
+		}
+	}
+}
+
+// BenchmarkNatsDispatch_ServiceStartStop benchmarks service lifecycle
+func BenchmarkNatsDispatch_ServiceStartStop(b *testing.B) {
+	nc := setupNATSConnection(b)
+	defer nc.Close()
+
+	transport := natstransport.New(nc)
+
+	gateway := zephyr.NewGateway("bench-gateway", transport)
+	gateway.Start()
+	defer gateway.Stop()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		service := zephyr.NewService(
+			fmt.Sprintf("lifecycle-service-%d", i%100),
+			transport,
+			simpleHandler,
+		)
+		service.Start()
+		service.Stop()
+	}
+}


### PR DESCRIPTION
- Introduced benchmark tests for high volume, concurrent requests, and large payloads in both local and NATS transports.
- Added memory profiling tests to check for memory growth and goroutine leaks during service registration and request handling.
- Implemented handlers for testing and profiling purposes.
- Enhanced NATS transport dispatch logic with proper subscription management to prevent leaks.
- Created dedicated test files for local and NATS transport benchmarks and memory tests.